### PR TITLE
Configure trusted CORS origins

### DIFF
--- a/main.py
+++ b/main.py
@@ -1,3 +1,6 @@
+import os
+from typing import List
+
 from fastapi.middleware.cors import CORSMiddleware
 
 from models.index import ChatMessage
@@ -7,10 +10,30 @@ from fastapi import FastAPI
 from fastapi.staticfiles import StaticFiles
 
 
+def _load_allowed_origins() -> List[str]:
+    """Return a list of allowed CORS origins.
+
+    Origins can be supplied via the ``ALLOWED_ORIGINS`` environment variable
+    as a comma separated list. When the variable is not provided, fall back to
+    a set of local development domains.
+    """
+
+    env_value = os.getenv("ALLOWED_ORIGINS")
+    if env_value:
+        return [origin.strip() for origin in env_value.split(",") if origin.strip()]
+
+    return [
+        "http://localhost",
+        "http://localhost:3000",
+        "http://127.0.0.1",
+        "http://127.0.0.1:3000",
+    ]
+
+
 app = FastAPI()
 app.add_middleware(
     CORSMiddleware,
-    allow_origins=["*"],
+    allow_origins=_load_allowed_origins(),
     allow_credentials=True,
     allow_methods=["*"],
     allow_headers=["*"],


### PR DESCRIPTION
## Summary
- load allowed CORS origins from the ALLOWED_ORIGINS environment variable when available
- default to a curated list of local development domains instead of the wildcard configuration

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68c8d3b264ac833194763d41c7b321a0