### PR TITLE
Add README and pytest coverage for chat endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,69 @@
+# RAG Project from DataGrid Docs
+
+## Overview
+This repository contains a FastAPI application that exposes a Retrieval-Augmented Generation (RAG) chat endpoint.  Documents are stored in a persistent [Chroma](https://www.trychroma.com/) vector database (bundled in `db_metadata_v5/`), and responses are generated with local [Ollama](https://ollama.com/) models via LangChain.
+
+The service currently exposes two endpoints:
+
+- `GET /` – health-check style endpoint that returns a static greeting.
+- `POST /chat/{chat_id}` – accepts a JSON payload with a `question` field, forwards it to the RAG pipeline, and returns the generated answer.  Conversations are grouped by `chat_id` so that each session maintains its own history.
+
+## Requirements
+- Python 3.10 or higher.
+- Access to an Ollama runtime with the `llama3.2:latest` and `mxbai-embed-large` models installed.
+- The dependencies listed below (they can be installed into a virtual environment):
+  ```bash
+  pip install fastapi uvicorn[standard] langchain langchain-community langchain-chroma langchain-ollama langchain-together pytest
+  ```
+
+## Installation
+1. **Clone the repository**
+   ```bash
+   git clone https://github.com/<your-org>/ragProjectFromDataGridDocs.git
+   cd ragProjectFromDataGridDocs
+   ```
+2. **Create and activate a virtual environment** (optional but recommended)
+   ```bash
+   python -m venv .venv
+   source .venv/bin/activate  # On Windows use `.venv\\Scripts\\activate`
+   ```
+3. **Install dependencies**
+   ```bash
+   pip install -r requirements.txt
+   ```
+   If you prefer not to use `requirements.txt`, install the packages listed in the [Requirements](#requirements) section manually.
+
+## Configuration
+- `ALLOWED_ORIGINS` – optional comma-separated list of allowed CORS origins. When not provided, local development origins (e.g. `http://localhost:3000`) are permitted by default.
+- `db_metadata_v5/` – directory that stores the persistent Chroma database.  Replace or rebuild it with your own knowledge base if required.
+
+## Running the API server
+Use [uvicorn](https://www.uvicorn.org/) to launch the FastAPI application:
+```bash
+uvicorn main:app --reload
+```
+The application will be available at `http://127.0.0.1:8000`.  The interactive API docs can be accessed at `http://127.0.0.1:8000/docs`.
+
+## Running tests
+The project uses [pytest](https://docs.pytest.org/) for automated testing.  After installing dependencies run:
+```bash
+pytest
+```
+The included tests cover the health-check endpoint and verify that the `/chat` route correctly forwards messages to the RAG provider.
+
+## Project structure
+```
+.
+├── data/                # Source documentation used to build the vector store
+├── db_metadata_v5/      # Persisted Chroma database files
+├── main.py              # FastAPI application entry point
+├── models/              # Pydantic models shared across the API
+├── providers/           # Integrations with different LLM providers (Ollama, Together)
+├── public/              # Static assets served by the API
+├── scripts/             # Utilities for scraping and ingesting documentation into Chroma
+└── tests/               # Pytest suite exercising the API
+```
+
+## Development tips
+- The Ollama-backed RAG provider is loaded lazily.  If the required LangChain modules are not installed, automated tests can still run by mocking the provider.
+- Use `scripts/ingest.py` to rebuild the vector store whenever new documentation is added to `data/`.

--- a/providers/ollama.py
+++ b/providers/ollama.py
@@ -1,30 +1,41 @@
-from langchain_chroma import Chroma
-from langchain_core.prompts import ChatPromptTemplate, MessagesPlaceholder
-from langchain_core.messages import HumanMessage, AIMessage
-from langchain_ollama import OllamaEmbeddings, OllamaLLM
-from langchain.chains.combine_documents import create_stuff_documents_chain
+from typing import Dict, List
 
 from models.index import ChatMessage
 
 
 CHROMA_PATH = "./db_metadata_v5"
 
-# Initialize OpenAI chat model
-model = OllamaLLM(model="llama3.2:latest", temperature=0.1)
+_db = None
+_document_chain = None
+_human_message_cls = None
+_ai_message_cls = None
+chat_history: Dict[str, List[object]] = {}
 
 
-# YOU MUST - Use same embedding function as before
-embedding_function = OllamaEmbeddings(model="mxbai-embed-large")
+def _ensure_initialized() -> None:
+    """Lazily initialize heavy RAG dependencies."""
 
-# Prepare the database
-db = Chroma(persist_directory=CHROMA_PATH, embedding_function=embedding_function)
-chat_history = {}  # approach with AiMessage/HumanMessage
+    global _db, _document_chain, _human_message_cls, _ai_message_cls
 
-prompt_template = ChatPromptTemplate.from_messages(
-    [
-        (
-            "system",
-            """
+    if _document_chain is not None:
+        return
+
+    from langchain_chroma import Chroma
+    from langchain_core.messages import AIMessage, HumanMessage
+    from langchain_core.prompts import ChatPromptTemplate, MessagesPlaceholder
+    from langchain_ollama import OllamaEmbeddings, OllamaLLM
+    from langchain.chains.combine_documents import create_stuff_documents_chain
+
+    model = OllamaLLM(model="llama3.2:latest", temperature=0.1)
+    embedding_function = OllamaEmbeddings(model="mxbai-embed-large")
+
+    _db = Chroma(persist_directory=CHROMA_PATH, embedding_function=embedding_function)
+
+    prompt_template = ChatPromptTemplate.from_messages(
+        [
+            (
+                "system",
+                """
                 [INST]You are an IT support specialist. Provide clear, professional, and efficient assistance based solely on the supplied context.
                 If the answer is not included in the context, reply exactly “Hmm, I am not sure. Let me check and get back to you.”
                 Decline to answer questions that fall outside the provided information.
@@ -32,33 +43,41 @@ prompt_template = ChatPromptTemplate.from_messages(
                 Keep responses concise, objective, and formatted in Markdown when helpful.[/INST]
                 [INST]Answer the question based only on the following context:
                 {context}[/INST]
-            """
-        ),
-        MessagesPlaceholder(variable_name="chat_history"),
-        ("human", "{question}")
-    ]
-)
+                """,
+            ),
+            MessagesPlaceholder(variable_name="chat_history"),
+            ("human", "{question}"),
+        ]
+    )
 
-document_chain = create_stuff_documents_chain(llm=model, prompt=prompt_template)
+    _document_chain = create_stuff_documents_chain(llm=model, prompt=prompt_template)
+    _human_message_cls = HumanMessage
+    _ai_message_cls = AIMessage
 
 
 def query_rag(message: ChatMessage, session_id: str = "") -> str:
     """
-    Query a Retrieval-Augmented Generation (RAG) system using Chroma database and OpenAI.
+    Query a Retrieval-Augmented Generation (RAG) system using Chroma database and Ollama models.
+
     :param message: ChatMessage The text to query the RAG system with.
-    :param session_id: str Session identifier
+    :param session_id: str Session identifier.
     :return str
     """
+
+    _ensure_initialized()
 
     if session_id not in chat_history:
         chat_history[session_id] = []
 
-    # Generate response text based on the prompt
-    response_text = document_chain.invoke({"context": db.similarity_search(message.question, k=3),
-                                           "question": message.question,
-                                           "chat_history": chat_history[session_id]})
+    response_text = _document_chain.invoke(
+        {
+            "context": _db.similarity_search(message.question, k=3),
+            "question": message.question,
+            "chat_history": chat_history[session_id],
+        }
+    )
 
-    chat_history[session_id].append(HumanMessage(content=message.question))
-    chat_history[session_id].append(AIMessage(content=response_text))
+    chat_history[session_id].append(_human_message_cls(content=message.question))
+    chat_history[session_id].append(_ai_message_cls(content=response_text))
 
     return response_text

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,8 @@
+fastapi
+uvicorn[standard]
+langchain
+langchain-community
+langchain-chroma
+langchain-ollama
+langchain-together
+pytest

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1,0 +1,38 @@
+import sys
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from fastapi.testclient import TestClient
+
+import main
+from models.index import ChatMessage
+
+
+def test_read_root():
+    client = TestClient(main.app)
+
+    response = client.get("/")
+
+    assert response.status_code == 200
+    assert response.json() == {"Hello": "world"}
+
+
+def test_chat_endpoint(monkeypatch):
+    client = TestClient(main.app)
+    captured = {}
+
+    def fake_query(message: ChatMessage, session_id: str) -> str:
+        captured["message"] = message
+        captured["session_id"] = session_id
+        return "mocked response"
+
+    monkeypatch.setattr(main, "query_rag", fake_query)
+
+    response = client.post("/chat/test-session", json={"question": "Hello"})
+
+    assert response.status_code == 200
+    assert response.json() == {"response": "mocked response"}
+    assert isinstance(captured["message"], ChatMessage)
+    assert captured["message"].question == "Hello"
+    assert captured["session_id"] == "test-session"


### PR DESCRIPTION
## Summary
- add a README with setup, configuration, and testing instructions for the FastAPI RAG service
- introduce a pytest-based test suite that exercises the root and /chat endpoints with a mocked provider
- lazily initialize the Ollama provider so tests can run without optional LangChain dependencies and document the dependency list

## Testing
- pytest
