### PR TITLE
Update requirements for Telegram bot support

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,6 @@
-fastapi
-uvicorn[standard]
 langchain
 langchain-community
 langchain-chroma
 langchain-ollama
+python-telegram-bot
 pytest


### PR DESCRIPTION
## Summary
- remove the FastAPI and uvicorn server dependencies from the requirements
- add python-telegram-bot while retaining the existing LangChain packages

## Testing
- `pip install -r requirements.txt`
