### PR TITLE
Enhance Ollama prompt with citation guidance

### DIFF
--- a/providers/ollama.py
+++ b/providers/ollama.py
@@ -40,6 +40,8 @@ def _ensure_initialized() -> None:
                 If the answer is not included in the context, reply exactly “Hmm, I am not sure. Let me check and get back to you.”
                 Decline to answer questions that fall outside the provided information.
                 Ask for clarification whenever a request is unclear.
+                Support statements with bracketed, numbered citations (e.g., [1], [2]) that correspond to the retrieved context snippets.
+                When an answer requires multiple steps, lay them out as an ordered list or clearly labeled sequence of steps.
                 Keep responses concise, objective, and formatted in Markdown when helpful.[/INST]
                 [INST]Answer the question based only on the following context:
                 {context}[/INST]

--- a/tests/test_query_rag.py
+++ b/tests/test_query_rag.py
@@ -1,4 +1,5 @@
 import sys
+import types
 from pathlib import Path
 
 sys.path.append(str(Path(__file__).resolve().parents[1]))
@@ -89,3 +90,71 @@ def test_query_rag_reuses_existing_history(monkeypatch):
     assert existing_history[-2].content == "Follow up"
     assert existing_history[-1].content == "answer:Follow up"
     assert len(existing_history) == 4
+
+
+def test_prompt_template_includes_guidance(monkeypatch):
+    captured = {}
+
+    class DummyPromptTemplate:
+        @classmethod
+        def from_messages(cls, messages):
+            captured["messages"] = messages
+            return "prompt"
+
+    class DummyMessagesPlaceholder:
+        def __init__(self, variable_name):
+            self.variable_name = variable_name
+
+    class DummyMessage:
+        def __init__(self, content=""):
+            self.content = content
+
+    class DummyLLM:
+        def __init__(self, *_, **__):
+            pass
+
+    class DummyEmbeddings(DummyLLM):
+        pass
+
+    class DummyChroma:
+        def __init__(self, *_, **__):
+            pass
+
+    def fake_create_chain(*_, **kwargs):
+        captured["chain_kwargs"] = kwargs
+        return "chain"
+
+    prompts_module = types.ModuleType("langchain_core.prompts")
+    setattr(prompts_module, "ChatPromptTemplate", DummyPromptTemplate)
+    setattr(prompts_module, "MessagesPlaceholder", DummyMessagesPlaceholder)
+
+    messages_module = types.ModuleType("langchain_core.messages")
+    setattr(messages_module, "AIMessage", DummyMessage)
+    setattr(messages_module, "HumanMessage", DummyMessage)
+
+    ollama_module = types.ModuleType("langchain_ollama")
+    setattr(ollama_module, "OllamaLLM", DummyLLM)
+    setattr(ollama_module, "OllamaEmbeddings", DummyEmbeddings)
+
+    chroma_module = types.ModuleType("langchain_chroma")
+    setattr(chroma_module, "Chroma", DummyChroma)
+
+    chains_module = types.ModuleType("langchain.chains.combine_documents")
+    setattr(chains_module, "create_stuff_documents_chain", fake_create_chain)
+
+    monkeypatch.setitem(sys.modules, "langchain_core.prompts", prompts_module)
+    monkeypatch.setitem(sys.modules, "langchain_core.messages", messages_module)
+    monkeypatch.setitem(sys.modules, "langchain_ollama", ollama_module)
+    monkeypatch.setitem(sys.modules, "langchain_chroma", chroma_module)
+    monkeypatch.setitem(sys.modules, "langchain.chains.combine_documents", chains_module)
+
+    monkeypatch.setattr(ollama, "_document_chain", None)
+    monkeypatch.setattr(ollama, "_db", None)
+    monkeypatch.setattr(ollama, "_human_message_cls", None)
+    monkeypatch.setattr(ollama, "_ai_message_cls", None)
+
+    ollama._ensure_initialized()
+
+    system_message = captured["messages"][0][1]
+    assert "numbered citations" in system_message
+    assert "ordered list" in system_message or "sequence of steps" in system_message


### PR DESCRIPTION
## Summary
- update the Ollama system prompt to require numbered citations and structured multi-step answers
- add a unit test that stubs langchain dependencies and verifies the prompt guidance text

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68ce3043c8d4833191401ed45d420a38