### PR TITLE
Fix only-adoc handling in ingest script

### DIFF
--- a/tests/test_ingest_adoc.py
+++ b/tests/test_ingest_adoc.py
@@ -1,0 +1,20 @@
+from pathlib import Path
+import sys
+
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+if str(PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(PROJECT_ROOT))
+
+def test_load_documents_only_adoc(tmp_path):
+    from scripts.ingest_adoc import load_documents
+
+    adoc_file = tmp_path / "sample.adoc"
+    adoc_file.write_text("= Title\n\nContent", encoding="utf-8")
+
+    md_file = tmp_path / "ignore.md"
+    md_file.write_text("# Heading", encoding="utf-8")
+
+    documents = load_documents(Path(tmp_path), file_extensions=(".adoc",))
+
+    assert len(documents) == 1
+    assert documents[0].metadata.get("source", "").endswith("sample.adoc")


### PR DESCRIPTION
## Summary
- allow the ingest script to accept explicit file extensions instead of rebinding the walker when --only-adoc is used
- support passing the filter through generate_data_store and cover the behavior with a targeted pytest

## Testing
- pytest tests/test_ingest_adoc.py
