### PR TITLE
Update README ingest reset instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,8 +117,11 @@ up any web framework components.
   rebuild the vector store whenever new documentation needs to be indexed.  All
   scripts look for content in `../data` by default; ensure that directory exists
   or provide an alternative with `--data-path /path/to/sources` before running
-  them.  Each script accepts an optional `--reset` flag to delete the existing
-  Chroma database before ingesting.
+  them.  The Markdown ingester always recreates the `db_metadata_v5/` directory
+  and does **not** accept `--reset`; use the flag with the AsciiDoc or Javadoc
+  scripts when you want them to wipe the database automatically.  For a clean
+  Markdown-only run, delete the `db_metadata_v5/` directory manually before
+  starting ingestion.
 
 ### Building a combined vector store
 


### PR DESCRIPTION
## Summary
- clarify that the Markdown ingestion script always recreates the Chroma database and does not accept --reset
- document that the AsciiDoc and Javadoc ingesters retain the --reset flag and recommend manual deletion before Markdown-only imports

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68db73c5d99483319bcadda7d8ec3576